### PR TITLE
quiz done

### DIFF
--- a/src/main/java/Problem3/Book.java
+++ b/src/main/java/Problem3/Book.java
@@ -2,7 +2,7 @@ package Problem3;
 
 import java.util.UUID;
 
-public abstract class Book implements StoreMediaOperations {
+public abstract class  Book implements StoreMediaOperations {
     UUID id;
     String title;
     String author;
@@ -17,6 +17,18 @@ public abstract class Book implements StoreMediaOperations {
         this.id = anotherBook.id;
         this.title = anotherBook.title;
         this.author = anotherBook.author;
+    }
+
+    public void setTitle(String newTitle){
+        this.title = newTitle;
+    }
+
+    public void setAuthor(String newAuthor){
+        this.author = newAuthor;
+    }
+
+    public void setId(UUID newId){
+        this.id = newId;
     }
 
     @Override
@@ -37,11 +49,11 @@ public abstract class Book implements StoreMediaOperations {
         // The bug is caught when
         //  1. newly add tests fail while all old tests still pass
         //  2. remove the bug and use the fix below, all tests pass
-        return id.equals(theOtherBook.id) &&
-                author.equals(theOtherBook.author) &&
-                title.equals(theOtherBook.title);
+        //return id.equals(theOtherBook.id) &&
+                //author.equals(theOtherBook.author) &&
+                //title.equals(theOtherBook.title);
 
         // fix is here
-        // return id.equals(theOtherBook.id);
+        return id.equals(theOtherBook.id);
     }
 }

--- a/src/main/java/Problem3/Movie.java
+++ b/src/main/java/Problem3/Movie.java
@@ -18,6 +18,17 @@ public abstract class Movie implements StoreMediaOperations {
         this.title = anotherMovie.title;
         this.id = anotherMovie.id;
     }
+    public void setTitle(String newTitle){
+        this.title = newTitle;
+    }
+
+    public void setAuthor(String newRating){
+        this.rating = newRating;
+    }
+
+    public void setId(UUID newId){
+        this.id = newId;
+    }
 
     @Override
     public boolean equals(Object obj) {
@@ -37,11 +48,12 @@ public abstract class Movie implements StoreMediaOperations {
         // The bug is caught when
         //  1. newly add tests fail while all old tests still pass
         //  2. remove the bug and use the fix below, all tests pass
-        return id.equals(theOtherMovie.id) &&
-                rating.equals(theOtherMovie.rating) &&
-                title.equals(theOtherMovie.title);
+
+        //return id.equals(theOtherMovie.id) &&
+                //rating.equals(theOtherMovie.rating) &&
+                //title.equals(theOtherMovie.title);
 
         // fix is here
-        //return this.id == ((Movie) obj).id;
+        return this.id == ((Movie) obj).id;
     }
 }

--- a/src/test/java/Problem3Test.java
+++ b/src/test/java/Problem3Test.java
@@ -7,11 +7,29 @@ public class Problem3Test {
     @Test
     public void catchTheBugInBook() {
         // quiz
+        BookFiction p1 = new BookFiction("t1", "au1", "g1");
+        BookFiction p2 = new BookFiction(p1);
+
+        //change title and author of p2, but not ID
+        p2.setTitle("t3");
+        p2.setAuthor("au3");
+
+        assert(p1.equals(p2));
+
     }
 
     @Test
     public void catchTheBugInMovie() {
         // quiz
+        MovieAction p1 = new MovieAction("t1", "au1");
+        MovieAction p2 = new MovieAction(p1);
+
+        //change title and author of p2, but not ID
+        p2.setTitle("t3");
+        p2.setAuthor("au3");
+
+        assert(p1.equals(p2));
+
     }
 
     // DO NOT REMOVE OR CHANGE ANYTHING BELOW THIS!


### PR DESCRIPTION
The reason why the test can pass is because the equals method compares the current object instance with the object that has been passed. In my tests, the objects are manipulated through setters allowing the fix to pass and fail without it. 